### PR TITLE
macOS support + NT results-only publishing

### DIFF
--- a/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NTDataPublisher.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NTDataPublisher.java
@@ -19,12 +19,8 @@ package org.photonvision.common.dataflow.networktables;
 
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.networktables.NetworkTableEvent;
 import edu.wpi.first.networktables.NetworkTablesJNI;
 import java.util.List;
-import java.util.function.BooleanSupplier;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 import org.photonvision.common.configuration.ConfigManager;
 import org.photonvision.common.dataflow.CVPipelineResultConsumer;
 import org.photonvision.common.logging.LogGroup;
@@ -43,111 +39,17 @@ public class NTDataPublisher implements CVPipelineResultConsumer {
 
     private final NTTopicSet ts = new NTTopicSet();
 
-    NTDataChangeListener pipelineIndexListener;
-    private final Supplier<Integer> pipelineIndexSupplier;
-    private final Consumer<Integer> pipelineIndexConsumer;
-
-    NTDataChangeListener driverModeListener;
-    private final BooleanSupplier driverModeSupplier;
-    private final Consumer<Boolean> driverModeConsumer;
-
-    NTDataChangeListener fpsLimitListener;
-    private final Consumer<Integer> fpsLimitConsumer;
-    private final Supplier<Integer> fpsLimitSupplier;
-
-    public NTDataPublisher(
-            String cameraNickname,
-            Supplier<Integer> pipelineIndexSupplier,
-            Consumer<Integer> pipelineIndexConsumer,
-            BooleanSupplier driverModeSupplier,
-            Consumer<Boolean> driverModeConsumer,
-            Supplier<Integer> fpsLimitSupplier,
-            Consumer<Integer> fpsLimitConsumer) {
-        this.pipelineIndexSupplier = pipelineIndexSupplier;
-        this.pipelineIndexConsumer = pipelineIndexConsumer;
-        this.driverModeSupplier = driverModeSupplier;
-        this.driverModeConsumer = driverModeConsumer;
-        this.fpsLimitSupplier = fpsLimitSupplier;
-        this.fpsLimitConsumer = fpsLimitConsumer;
-
+    public NTDataPublisher(String cameraNickname) {
         updateCameraNickname(cameraNickname);
-        updateEntries();
-    }
-
-    private void onPipelineIndexChange(NetworkTableEvent entryNotification) {
-        var newIndex = (int) entryNotification.valueData.value.getInteger();
-        var originalIndex = pipelineIndexSupplier.get();
-
-        // ignore indexes below 0
-        if (newIndex < 0) {
-            ts.pipelineIndexPublisher.set(originalIndex);
-            return;
-        }
-
-        if (newIndex == originalIndex) {
-            logger.debug("Pipeline index is already " + newIndex);
-            return;
-        }
-
-        pipelineIndexConsumer.accept(newIndex);
-        var setIndex = pipelineIndexSupplier.get();
-        if (newIndex != setIndex) { // set failed
-            ts.pipelineIndexPublisher.set(setIndex);
-            // TODO: Log
-        }
-        logger.debug("Set pipeline index to " + newIndex);
-    }
-
-    private void onDriverModeChange(NetworkTableEvent entryNotification) {
-        var newDriverMode = entryNotification.valueData.value.getBoolean();
-        var originalDriverMode = driverModeSupplier.getAsBoolean();
-
-        if (newDriverMode == originalDriverMode) {
-            logger.debug("Driver mode is already " + newDriverMode);
-            return;
-        }
-
-        driverModeConsumer.accept(newDriverMode);
-        logger.debug("Set driver mode to " + newDriverMode);
-    }
-
-    private void onFPSLimitChange(NetworkTableEvent entryNotification) {
-        var newFPSLimit = (int) entryNotification.valueData.value.getInteger();
-        var originalFPSLimit = fpsLimitSupplier.get();
-
-        if (newFPSLimit == originalFPSLimit) {
-            logger.debug("FPS limit is already " + newFPSLimit);
-            return;
-        }
-
-        fpsLimitConsumer.accept(newFPSLimit);
-        logger.debug("Set FPS limit to " + newFPSLimit);
+        ts.updateEntries();
     }
 
     private void removeEntries() {
-        if (pipelineIndexListener != null) pipelineIndexListener.remove();
-        if (driverModeListener != null) driverModeListener.remove();
         ts.removeEntries();
     }
 
     private void updateEntries() {
-        if (pipelineIndexListener != null) pipelineIndexListener.remove();
-        if (driverModeListener != null) driverModeListener.remove();
-        if (fpsLimitListener != null) fpsLimitListener.remove();
-
         ts.updateEntries();
-
-        pipelineIndexListener =
-                new NTDataChangeListener(
-                        ts.subTable.getInstance(), ts.pipelineIndexRequestSub, this::onPipelineIndexChange);
-
-        driverModeListener =
-                new NTDataChangeListener(
-                        ts.subTable.getInstance(), ts.driverModeSubscriber, this::onDriverModeChange);
-
-        fpsLimitListener =
-                new NTDataChangeListener(
-                        ts.subTable.getInstance(), ts.fpsLimitSubscriber, this::onFPSLimitChange);
     }
 
     public void updateCameraNickname(String newCameraNickname) {
@@ -194,9 +96,6 @@ public class NTDataPublisher implements CVPipelineResultConsumer {
             ts.protoResultPublisher.set(simplified);
         }
 
-        ts.pipelineIndexPublisher.set(pipelineIndexSupplier.get());
-        ts.driverModePublisher.set(driverModeSupplier.getAsBoolean());
-        ts.fpsLimitPublisher.set(fpsLimitSupplier.get());
         ts.latencyMillisEntry.set(acceptedResult.getLatencyMillis());
         ts.fpsEntry.set(acceptedResult.fps);
         ts.hasTargetEntry.set(acceptedResult.hasTargets());
@@ -223,18 +122,6 @@ public class NTDataPublisher implements CVPipelineResultConsumer {
             ts.targetPoseEntry.set(new Transform3d());
             ts.bestTargetPosX.set(0);
             ts.bestTargetPosY.set(0);
-        }
-
-        // Something in the result can sometimes be null -- so check probably too many things
-        if (acceptedResult.inputAndOutputFrame != null
-                && acceptedResult.inputAndOutputFrame.frameStaticProperties != null
-                && acceptedResult.inputAndOutputFrame.frameStaticProperties.cameraCalibration != null) {
-            var fsp = acceptedResult.inputAndOutputFrame.frameStaticProperties;
-            ts.cameraIntrinsicsPublisher.accept(fsp.cameraCalibration.getIntrinsicsArr());
-            ts.cameraDistortionPublisher.accept(fsp.cameraCalibration.getDistCoeffsArr());
-        } else {
-            ts.cameraIntrinsicsPublisher.accept(new double[0]);
-            ts.cameraDistortionPublisher.accept(new double[0]);
         }
 
         ts.heartbeatPublisher.set(acceptedResult.sequenceID);

--- a/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
+++ b/photon-core/src/main/java/org/photonvision/common/dataflow/networktables/NetworkTablesManager.java
@@ -17,7 +17,6 @@
 
 package org.photonvision.common.dataflow.networktables;
 
-import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.cscore.CameraServerJNI;
 import edu.wpi.first.networktables.LogMessage;
 import edu.wpi.first.networktables.MultiSubscriber;
@@ -25,13 +24,10 @@ import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEvent;
 import edu.wpi.first.networktables.NetworkTableEvent.Kind;
 import edu.wpi.first.networktables.NetworkTableInstance;
-import edu.wpi.first.networktables.StringSubscriber;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Alert.AlertType;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import java.io.IOException;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.HashMap;
 import org.photonvision.PhotonVersion;
 import org.photonvision.common.configuration.CameraConfiguration;
@@ -46,7 +42,6 @@ import org.photonvision.common.logging.LogLevel;
 import org.photonvision.common.logging.Logger;
 import org.photonvision.common.networking.NetworkUtils;
 import org.photonvision.common.util.TimedTaskManager;
-import org.photonvision.common.util.file.JacksonUtils;
 
 public class NetworkTablesManager {
     private static final Logger logger =
@@ -56,7 +51,6 @@ public class NetworkTablesManager {
     private final String kRootTableName = "/photonvision";
     // The coprocessors table should only be used for operations/data related to MAC address
     public final String kCoprocTableName = "coprocessors";
-    private final String kFieldLayoutName = "apriltag_field_layout";
     public final NetworkTable kRootTable = ntInstance.getTable(kRootTableName);
     public final NetworkTable kCoprocTable = kRootTable.getSubTable(kCoprocTableName);
 
@@ -76,9 +70,6 @@ public class NetworkTablesManager {
 
     private boolean m_isRetryingConnection = false;
 
-    private StringSubscriber m_fieldLayoutSubscriber =
-            kRootTable.getStringTopic(kFieldLayoutName).subscribe("");
-
     private final TimeSyncManager m_timeSync = new TimeSyncManager(kRootTable);
 
     NTDriverStation ntDriverStation;
@@ -87,9 +78,6 @@ public class NetworkTablesManager {
         ntInstance.addLogger(
                 LogMessage.kInfo, LogMessage.kCritical, this::logNtMessage); // to hide error messages
         ntInstance.addConnectionListener(true, this::checkNtConnectState); // to hide error messages
-
-        ntInstance.addListener(
-                m_fieldLayoutSubscriber, EnumSet.of(Kind.kValueAll), this::onFieldLayoutChanged);
 
         ntDriverStation = new NTDriverStation(this.getNTInst());
 
@@ -193,24 +181,6 @@ public class NetworkTablesManager {
 
     public NetworkTableInstance getNTInst() {
         return ntInstance;
-    }
-
-    private void onFieldLayoutChanged(NetworkTableEvent event) {
-        var atfl_json = event.valueData.value.getString();
-        try {
-            System.out.println("Got new field layout!");
-            var atfl = JacksonUtils.deserialize(atfl_json, AprilTagFieldLayout.class);
-            ConfigManager.getInstance().getConfig().setApriltagFieldLayout(atfl);
-            ConfigManager.getInstance().requestSave();
-            DataChangeService.getInstance()
-                    .publishEvent(
-                            new OutgoingUIEvent<>(
-                                    "fullsettings",
-                                    UIPhotonConfiguration.programStateToUi(ConfigManager.getInstance().getConfig())));
-        } catch (IOException e) {
-            logger.error("Error deserializing atfl!");
-            logger.error(atfl_json);
-        }
     }
 
     public void broadcastConnectedStatus() {

--- a/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
+++ b/photon-core/src/main/java/org/photonvision/vision/processes/VisionModule.java
@@ -147,13 +147,7 @@ public class VisionModule {
 
         ntConsumer =
                 new NTDataPublisher(
-                        visionSource.getSettables().getConfiguration().nickname,
-                        pipelineManager::getRequestedIndex,
-                        this::setPipeline,
-                        pipelineManager::getDriverMode,
-                        this::setDriverMode,
-                        this::getFPSLimit,
-                        this::setFPSLimit);
+                        visionSource.getSettables().getConfiguration().nickname);
         uiDataConsumer = new UIDataPublisher(visionSource.getSettables().getConfiguration().uniqueName);
         statusLEDsConsumer =
                 new StatusLEDConsumer(visionSource.getSettables().getConfiguration().uniqueName);

--- a/photon-lib/src/main/java/org/photonvision/simulation/PhotonCameraSim.java
+++ b/photon-lib/src/main/java/org/photonvision/simulation/PhotonCameraSim.java
@@ -34,6 +34,7 @@ import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.Pair;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.networktables.DoubleArrayPublisher;
 import edu.wpi.first.util.PixelFormat;
 import edu.wpi.first.util.WPIUtilJNI;
 import edu.wpi.first.wpilibj.RobotController;
@@ -72,6 +73,9 @@ public class PhotonCameraSim implements AutoCloseable {
     @SuppressWarnings("doclint")
     protected NTTopicSet ts = new NTTopicSet();
 
+    private DoubleArrayPublisher cameraIntrinsicsPublisher;
+    private DoubleArrayPublisher cameraDistortionPublisher;
+
     private long heartbeatCounter = 1;
 
     /** This simulated camera's {@link SimCameraProperties} */
@@ -106,6 +110,8 @@ public class PhotonCameraSim implements AutoCloseable {
         videoSimFrameRaw.release();
         videoSimProcessed.close();
         videoSimFrameProcessed.release();
+        if (cameraIntrinsicsPublisher != null) cameraIntrinsicsPublisher.close();
+        if (cameraDistortionPublisher != null) cameraDistortionPublisher.close();
     }
 
     /**
@@ -162,6 +168,13 @@ public class PhotonCameraSim implements AutoCloseable {
         ts.removeEntries();
         ts.subTable = camera.getCameraTable();
         ts.updateEntries();
+
+        if (cameraIntrinsicsPublisher != null) cameraIntrinsicsPublisher.close();
+        if (cameraDistortionPublisher != null) cameraDistortionPublisher.close();
+        cameraIntrinsicsPublisher =
+                ts.subTable.getDoubleArrayTopic("cameraIntrinsics").publish();
+        cameraDistortionPublisher =
+                ts.subTable.getDoubleArrayTopic("cameraDistortion").publish();
     }
 
     /**
@@ -697,8 +710,8 @@ public class PhotonCameraSim implements AutoCloseable {
             ts.targetPoseEntry.set(transform, receiveTimestamp);
         }
 
-        ts.cameraIntrinsicsPublisher.set(prop.getIntrinsics().getData(), receiveTimestamp);
-        ts.cameraDistortionPublisher.set(prop.getDistCoeffs().getData(), receiveTimestamp);
+        cameraIntrinsicsPublisher.set(prop.getIntrinsics().getData(), receiveTimestamp);
+        cameraDistortionPublisher.set(prop.getDistCoeffs().getData(), receiveTimestamp);
 
         ts.heartbeatPublisher.set(heartbeatCounter, receiveTimestamp);
         heartbeatCounter += 1;

--- a/photon-server/src/main/java/org/photonvision/Main.java
+++ b/photon-server/src/main/java/org/photonvision/Main.java
@@ -257,13 +257,6 @@ public class Main {
             logger.error("Failed to parse command-line options!", e);
         }
 
-        // We don't want to trigger an exit in test mode or smoke test. This is
-        // specifically for MacOS.
-        if (!(Platform.isSupported() || isSmoketest || isTestMode)) {
-            logger.error("This platform is unsupported!");
-            System.exit(1);
-        }
-
         try {
             boolean success = LoadJNI.loadLibraries();
 

--- a/photon-targeting/src/main/java/org/photonvision/common/hardware/Platform.java
+++ b/photon-targeting/src/main/java/org/photonvision/common/hardware/Platform.java
@@ -68,7 +68,7 @@ public enum Platform {
 
     // Completely unsupported
     WINDOWS_32("Windows x86", Platform::getUnknownModel, false, OSType.WINDOWS, false),
-    MACOS("Mac OS", Platform::getUnknownModel, false, OSType.MACOS, false),
+    MACOS("Mac OS", Platform::getUnknownModel, false, OSType.MACOS, true),
     LINUX_ARM32(
             "Linux ARM32", Platform::getUnknownModel, false, OSType.LINUX, false), // ODROID XU4, C1+
     UNKNOWN("Unsupported Platform", Platform::getUnknownModel, false, OSType.UNKNOWN, false);

--- a/photon-targeting/src/main/java/org/photonvision/common/networktables/NTTopicSet.java
+++ b/photon-targeting/src/main/java/org/photonvision/common/networktables/NTTopicSet.java
@@ -19,12 +19,8 @@ package org.photonvision.common.networktables;
 
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.networktables.BooleanPublisher;
-import edu.wpi.first.networktables.BooleanSubscriber;
-import edu.wpi.first.networktables.BooleanTopic;
-import edu.wpi.first.networktables.DoubleArrayPublisher;
 import edu.wpi.first.networktables.DoublePublisher;
 import edu.wpi.first.networktables.IntegerPublisher;
-import edu.wpi.first.networktables.IntegerSubscriber;
 import edu.wpi.first.networktables.IntegerTopic;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.ProtobufPublisher;
@@ -47,16 +43,6 @@ public class NTTopicSet {
     public PacketPublisher<PhotonPipelineResult> resultPublisher;
     public ProtobufPublisher<PhotonPipelineResult> protoResultPublisher;
 
-    public IntegerPublisher pipelineIndexPublisher;
-    public IntegerSubscriber pipelineIndexRequestSub;
-
-    public BooleanTopic driverModeEntry;
-    public BooleanPublisher driverModePublisher;
-    public BooleanSubscriber driverModeSubscriber;
-
-    public IntegerPublisher fpsLimitPublisher;
-    public IntegerSubscriber fpsLimitSubscriber;
-
     public DoublePublisher latencyMillisEntry;
     public DoublePublisher fpsEntry;
     public BooleanPublisher hasTargetEntry;
@@ -73,10 +59,6 @@ public class NTTopicSet {
     // Heartbeat
     public IntegerTopic heartbeatTopic;
     public IntegerPublisher heartbeatPublisher;
-
-    // Camera Calibration
-    public DoubleArrayPublisher cameraIntrinsicsPublisher;
-    public DoubleArrayPublisher cameraDistortionPublisher;
 
     public void updateEntries() {
         var rawBytesEntry =
@@ -95,20 +77,6 @@ public class NTTopicSet {
                         .getProtobufTopic("result_proto", PhotonPipelineResult.proto)
                         .publish(PubSubOption.periodic(0.01), PubSubOption.sendAll(true));
 
-        pipelineIndexPublisher = subTable.getIntegerTopic("pipelineIndexState").publish();
-        pipelineIndexRequestSub = subTable.getIntegerTopic("pipelineIndexRequest").subscribe(0);
-
-        driverModePublisher = subTable.getBooleanTopic("driverMode").publish();
-        driverModeSubscriber = subTable.getBooleanTopic("driverModeRequest").subscribe(false);
-
-        // Fun little hack to make the request show up
-        driverModeSubscriber.getTopic().publish().setDefault(false);
-
-        fpsLimitPublisher = subTable.getIntegerTopic("fpsLimit").publish();
-        fpsLimitSubscriber = subTable.getIntegerTopic("fpsLimitRequest").subscribe(-1);
-
-        fpsLimitSubscriber.getTopic().publish().setDefault(-1);
-
         latencyMillisEntry = subTable.getDoubleTopic("latencyMillis").publish();
         fpsEntry = subTable.getDoubleTopic("fps").publish();
         hasTargetEntry = subTable.getBooleanTopic("hasTarget").publish();
@@ -124,22 +92,11 @@ public class NTTopicSet {
 
         heartbeatTopic = subTable.getIntegerTopic("heartbeat");
         heartbeatPublisher = heartbeatTopic.publish();
-
-        cameraIntrinsicsPublisher = subTable.getDoubleArrayTopic("cameraIntrinsics").publish();
-        cameraDistortionPublisher = subTable.getDoubleArrayTopic("cameraDistortion").publish();
     }
 
     @SuppressWarnings("DuplicatedCode")
     public void removeEntries() {
         if (resultPublisher != null) resultPublisher.close();
-        if (pipelineIndexPublisher != null) pipelineIndexPublisher.close();
-        if (pipelineIndexRequestSub != null) pipelineIndexRequestSub.close();
-
-        if (driverModePublisher != null) driverModePublisher.close();
-        if (driverModeSubscriber != null) driverModeSubscriber.close();
-
-        if (fpsLimitPublisher != null) fpsLimitPublisher.close();
-        if (fpsLimitSubscriber != null) fpsLimitSubscriber.close();
 
         if (latencyMillisEntry != null) latencyMillisEntry.close();
         if (fpsEntry != null) fpsEntry.close();
@@ -153,8 +110,5 @@ public class NTTopicSet {
         if (bestTargetPosY != null) bestTargetPosY.close();
 
         if (heartbeatPublisher != null) heartbeatPublisher.close();
-
-        if (cameraIntrinsicsPublisher != null) cameraIntrinsicsPublisher.close();
-        if (cameraDistortionPublisher != null) cameraDistortionPublisher.close();
     }
 }


### PR DESCRIPTION
- Mark macOS as a supported platform in Platform.java
- Remove the platform support check in Main.java that exited on macOS
- Remove all camera settings from NT publishing (pipeline index, driver mode, fps limit, camera intrinsics/distortion)
- Remove the apriltag field layout subscriber from NT
- NTDataPublisher now only publishes vision results to NT
- PhotonCameraSim publishes intrinsics/distortion directly instead of through NTTopicSet

https://claude.ai/code/session_01EfivnKEs8qbAeEBHL6BoNn

## Description

What changed? Why? (the code + comments should speak for itself on the "how")

Include fun testing screenshots or a cool video, to collect test evidence in a place where we can later reference it. Including proof this change was tested makes reviewing easier, helps us make sure we tested all our edge cases, and helps provide context for the future.

Any issues this pull request closes or pull requests this supersedes should be linked with `Closes #issuenumber`.

## Meta

Merge checklist:
- [ ] Pull Request title is [short, imperative summary](https://cbea.ms/git-commit/) of proposed changes
- [ ] The description documents the _what_ and _why_, including events that led to this PR
- [ ] If this PR changes behavior or adds a feature, user documentation is updated
- [ ] If this PR touches photon-serde, all messages have been regenerated and hashes have not changed unexpectedly
- [ ] If this PR touches configuration, this is backwards compatible with all settings going back to the previous seasons's last release (seasons end after champs ends)
- [ ] If this PR touches pipeline settings or anything related to data exchange, the frontend typing is updated
- [ ] If this PR addresses a bug, a regression test for it is added
- [ ] If this PR adds a dependency, the license has been checked for compatibility and steps taken to follow it
